### PR TITLE
Assign resources to identity by resource's identifier and type instead of id

### DIFF
--- a/identity-api/identity-api-client/src/main/java/com/sflpro/identity/api/client/ResourceResource.java
+++ b/identity-api/identity-api-client/src/main/java/com/sflpro/identity/api/client/ResourceResource.java
@@ -10,9 +10,6 @@ import com.sflpro.identity.api.common.dtos.resource.ResourceUpdateRequestDto;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.GenericType;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
 
 /**
  * Company: SFL LLC
@@ -39,15 +36,6 @@ public class ResourceResource extends AbstractApiResource {
 
     public ApiResponseDto delete(final long resourceId) {
         return doDelete(Long.toString(resourceId), ApiResponseDto.class);
-    }
-
-    public ApiGenericListResponse<ResourceDto> list(final String type, final String identifier){
-        Map<String, String> params = new HashMap<>();
-        Optional.ofNullable(type)
-                .ifPresent(t -> params.put("type", t));
-        Optional.ofNullable(identifier)
-                .ifPresent(i -> params.put("identifier", i));
-        return doGet("", new GenericType<ApiGenericListResponse<ResourceDto>>() {}, params);
     }
 
     public ApiGenericListResponse<IdentityDto> listIdentities(final long resourceId){

--- a/identity-api/identity-api-common/src/main/java/com/sflpro/identity/api/common/dtos/identity/IdentityResourceUpdateRequestDto.java
+++ b/identity-api/identity-api-common/src/main/java/com/sflpro/identity/api/common/dtos/identity/IdentityResourceUpdateRequestDto.java
@@ -1,5 +1,7 @@
 package com.sflpro.identity.api.common.dtos.identity;
 
+import com.sflpro.identity.api.common.dtos.resource.ResourceRequestDto;
+
 import javax.validation.constraints.NotEmpty;
 import java.util.List;
 
@@ -12,13 +14,13 @@ import java.util.List;
 public class IdentityResourceUpdateRequestDto {
 
     @NotEmpty
-    private List<Long> resourceIds;
+    private List<ResourceRequestDto> resourceRequests;
 
-    public List<Long> getResourceIds() {
-        return resourceIds;
+    public List<ResourceRequestDto> getResourceRequests() {
+        return resourceRequests;
     }
 
-    public void setResourceIds(List<Long> resourceIds) {
-        this.resourceIds = resourceIds;
+    public void setResourceRequests(List<ResourceRequestDto> resourceRequests) {
+        this.resourceRequests = resourceRequests;
     }
 }

--- a/identity-api/identity-api-facade/src/main/java/com/sflpro/identity/api/endpoints/ResourceEndpoint.java
+++ b/identity-api/identity-api-facade/src/main/java/com/sflpro/identity/api/endpoints/ResourceEndpoint.java
@@ -102,18 +102,6 @@ public class ResourceEndpoint {
         return new ApiResponseDto();
     }
 
-    @ApiOperation("Lists resources")
-    @GET
-    @Transactional(readOnly = true)
-    public ApiGenericListResponse<ResourceDto> list(@QueryParam("type") final String type,
-                                                    @QueryParam("identifier") final String identifier) {
-        // list resources
-        List<Resource> resources = resourceService.list(type, identifier);
-        logger.info("Found {} resources", resources.size());
-        List<ResourceDto> result = mapper.mapAsList(resources, ResourceDto.class);
-        return new ApiGenericListResponse<>(result.size(), result);
-    }
-
     @ApiOperation("Lists resource's identities")
     @GET
     @Path("/{resourceId}/identities")

--- a/identity-core/identity-core-db-repositories/src/main/java/com/sflpro/identity/core/db/repositories/ResourceRepository.java
+++ b/identity-core/identity-core-db-repositories/src/main/java/com/sflpro/identity/core/db/repositories/ResourceRepository.java
@@ -2,10 +2,6 @@ package com.sflpro.identity.core.db.repositories;
 
 import com.sflpro.identity.core.db.entities.Resource;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
-
-import java.util.List;
 
 /**
  * Company: SFL LLC
@@ -15,11 +11,5 @@ import java.util.List;
  */
 public interface ResourceRepository extends JpaRepository<Resource, Long> {
 
-    @Query("select r " +
-            "from Resource r " +
-            "where (:type is null or r.type = :type) " +
-            "and (:identifier is null or r.identifier = :identifier) " +
-            "and r.deleted is null " +
-            "order by r.type, r.identifier")
-    List<Resource> search(@Param("type") String type, @Param("identifier") String identifier);
+    Resource findFirstByDeletedIsNullAndTypeAndIdentifier(String type, String identifier);
 }

--- a/identity-core/identity-core-services-impl/src/main/java/com/sflpro/identity/core/services/identity/IdentityServiceImpl.java
+++ b/identity-core/identity-core-services-impl/src/main/java/com/sflpro/identity/core/services/identity/IdentityServiceImpl.java
@@ -15,6 +15,7 @@ import com.sflpro.identity.core.services.identity.reset.RequestSecretResetReques
 import com.sflpro.identity.core.services.identity.reset.SecretResetRequest;
 import com.sflpro.identity.core.services.notification.NotificationCommunicationService;
 import com.sflpro.identity.core.services.principal.PrincipalService;
+import com.sflpro.identity.core.services.resource.ResourceCreationRequest;
 import com.sflpro.identity.core.services.resource.ResourceService;
 import com.sflpro.identity.core.services.token.*;
 import org.apache.commons.lang3.StringUtils;
@@ -245,13 +246,23 @@ public class IdentityServiceImpl implements IdentityService {
     public List<Resource> updateIdentityResources(IdentityResourceUpdateRequest updateRequest) {
         Assert.notNull(updateRequest, "updateRequest cannot be null");
         Assert.notNull(updateRequest.getIdentityId(), "updateRequest.identity id cannot be null");
-        Assert.notNull(updateRequest.getResourceIds(), "updateRequest.details cannot be null");
+        Assert.notNull(updateRequest.getResourceRequests(), "updateRequest.resourceRequests cannot be null");
         logger.debug("Updating resources of identity: {}", updateRequest);
         Identity identity = get(updateRequest.getIdentityId());
 
         identityResourceRepository.deleteAllByIdentityId(identity.getId());
         entityManager.flush();
-        List<Resource> result = resourceService.getByIds(updateRequest.getResourceIds()).stream()
+        List<Resource> result = updateRequest.getResourceRequests().stream()
+                .map(r -> {
+                    List<Resource> list = resourceService.list(r.getType(), r.getIdentifier());
+                    if(list.isEmpty() || list.get(0) == null) {
+                        ResourceCreationRequest creationRequest = new ResourceCreationRequest();
+                        creationRequest.setType(r.getType());
+                        creationRequest.setIdentifier(r.getIdentifier());
+                        return resourceService.create(creationRequest);
+                    }
+                    return list.get(0);
+                })
                 .map(r -> insert(identity, r))
                 .map(IdentityResource::getResource)
                 .collect(Collectors.toList());

--- a/identity-core/identity-core-services-impl/src/main/java/com/sflpro/identity/core/services/resource/ResourceServiceImpl.java
+++ b/identity-core/identity-core-services-impl/src/main/java/com/sflpro/identity/core/services/resource/ResourceServiceImpl.java
@@ -113,13 +113,4 @@ public class ResourceServiceImpl implements ResourceService {
         logger.trace("Complete getting resources for identity {}.", identity);
         return resources;
     }
-
-    @Override
-    @Transactional(readOnly = true)
-    public List<Resource> getByIds(final List<Long> resourceIds) {
-        logger.debug("Trying to get resources with ids: '{}'.", resourceIds);
-        List<Resource> resources = resourceRepository.findAllById(resourceIds);
-        logger.trace("Finished getting resources from ids '{}'", resourceIds);
-        return resources;
-    }
 }

--- a/identity-core/identity-core-services-impl/src/main/java/com/sflpro/identity/core/services/resource/ResourceServiceImpl.java
+++ b/identity-core/identity-core-services-impl/src/main/java/com/sflpro/identity/core/services/resource/ResourceServiceImpl.java
@@ -88,11 +88,11 @@ public class ResourceServiceImpl implements ResourceService {
 
     @Override
     @Transactional(readOnly = true)
-    public List<Resource> list(String type, String identifier) {
+    public Resource get(String type, String identifier) {
         logger.debug("Trying to to list resources with type: '{}' and identifier: {}.", type, identifier);
-        List<Resource> resources = resourceRepository.search(type, identifier);
-        logger.trace("Finished listing resources with '{}' type and '{}' identifier.", type, identifier);
-        return resources;
+        Resource resource = resourceRepository.findFirstByDeletedIsNullAndTypeAndIdentifier(type, identifier);
+        logger.trace("Finished finding resource with '{}' type and '{}' identifier.", type, identifier);
+        return resource;
     }
 
     @Override

--- a/identity-core/identity-core-services/src/main/java/com/sflpro/identity/core/services/identity/IdentityResourceUpdateRequest.java
+++ b/identity-core/identity-core-services/src/main/java/com/sflpro/identity/core/services/identity/IdentityResourceUpdateRequest.java
@@ -1,5 +1,7 @@
 package com.sflpro.identity.core.services.identity;
 
+import com.sflpro.identity.core.services.resource.ResourceRequest;
+
 import java.util.List;
 
 /**
@@ -12,7 +14,7 @@ public class IdentityResourceUpdateRequest {
 
     private String identityId;
 
-    private List<Long> resourceIds;
+    private List<ResourceRequest> resourceRequests;
 
     public String getIdentityId() {
         return identityId;
@@ -22,11 +24,11 @@ public class IdentityResourceUpdateRequest {
         this.identityId = identityId;
     }
 
-    public List<Long> getResourceIds() {
-        return resourceIds;
+    public List<ResourceRequest> getResourceRequests() {
+        return resourceRequests;
     }
 
-    public void setResourceIds(List<Long> resourceIds) {
-        this.resourceIds = resourceIds;
+    public void setResourceRequests(List<ResourceRequest> resourceRequests) {
+        this.resourceRequests = resourceRequests;
     }
 }

--- a/identity-core/identity-core-services/src/main/java/com/sflpro/identity/core/services/resource/ResourceService.java
+++ b/identity-core/identity-core-services/src/main/java/com/sflpro/identity/core/services/resource/ResourceService.java
@@ -21,7 +21,7 @@ public interface ResourceService {
 
     Resource delete(final long resourceId);
 
-    List<Resource> list(final String resourceType, String resourceIdentifier);
+    Resource get(final String resourceType, String resourceIdentifier);
 
     List<Resource> search(final String identityId, String resourceType, String resourceIdentifier);
 

--- a/identity-core/identity-core-services/src/main/java/com/sflpro/identity/core/services/resource/ResourceService.java
+++ b/identity-core/identity-core-services/src/main/java/com/sflpro/identity/core/services/resource/ResourceService.java
@@ -26,6 +26,4 @@ public interface ResourceService {
     List<Resource> search(final String identityId, String resourceType, String resourceIdentifier);
 
     List<Resource> get(final List<ResourceRequest> resourceRequests, final Identity identity);
-
-    List<Resource> getByIds(final List<Long> resourceIds);
 }


### PR DESCRIPTION
* Use ResourceRequest instead of resource ids in assigning resources to identity endpoint
* Remove redundant code